### PR TITLE
Update lists.rst to fix grammar

### DIFF
--- a/source/lists.rst
+++ b/source/lists.rst
@@ -18,7 +18,7 @@ Use hash symbols for ordered lists:
  Ordered lists usually use numerals. Nested ordered lists (ordered lists inside
  other ordered lists) use letters.
 
- An ordered lists should have 3-7 items.
+ An ordered list should have 3-7 items.
 
 Unordered Lists
 ***************
@@ -31,7 +31,7 @@ Use asterisks for unordered (bulleted) lists.
     * Item 2.
     * Item 3.
 
-An unordered lists should have 3-7 items.
+An unordered list should have 3-7 items.
 
 Unordered List Inside Ordered List
 *********************************************


### PR DESCRIPTION
P. S., say why "3-7" items?

Also you need to add surrounding code, so the user sees if he or she needs a blank line before or after lists... like we do on GitHub Markdown.